### PR TITLE
Enable cert-manager cilium network policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bump `observability-bundle` app to 0.8.4.
 - Bump `vertical-pod-autoscaler` app to 4.0.0.
 
+### Fixed
+
+- Enable cilium network policies for:
+  - cert-manager
+  - observability-bundle
+
 ## [0.1.2] - 2023-08-09
 
 - Bump `external-dns` app.

--- a/helm/default-apps-eks/values.yaml
+++ b/helm/default-apps-eks/values.yaml
@@ -19,6 +19,8 @@ userConfig:
         #
         # For public clusters, this setting should have no effect, as they can use the HTTP01 solver.
         dns01RecursiveNameserversOnly: true
+        ciliumNetworkPolicy:
+          enabled: true
   externalDns:
     configMap:
       values: |
@@ -43,6 +45,11 @@ userConfig:
       values: |
         NetExporter:
           NTPServers: 169.254.169.123
+  observabilityBundle:
+    configMap:
+      values: |
+        ciliumNetworkPolicy:
+          enabled: true
 apps:
   capi-node-labeler:
     appName: capi-node-labeler


### PR DESCRIPTION
### What this PR does / why we need it

This PR enabled cilium network policy for cert-manager and the observability-bundle towards https://github.com/giantswarm/giantswarm/issues/28250#issuecomment-1733624184

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!--
We currently have two different pipelines to test both cluster creation and cluster upgrades. You can trigger these pipelines by writing these commands in a pull request comment or description
- `/test create` : this will trigger the `create-cluster-capi-pure` pipeline.
- `/test upgrade` : this will trigger the `upgrade-cluster-capi-pure` pipeline.

After writing these comments, the pipelines are triggered in [tekton](https://tekton.giantswarm.io/#/pipelineruns). Eventually, the Github checks `create` and `upgrade` for these pipelines should show up in the commit statuses.
It may happen that the status is never shown on Github UI. If you want to check the status or result of the pipelines you can check [tekton](https://tekton.giantswarm.io/#/pipelineruns).

If for some reason you want to skip the e2e tests, remove the following lines.
-->

/test create
/test upgrade
/run cluster-test-suites
