### PR TITLE
Bump cert-exporter to support servicemonitors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Bump `cert-manager-app` app to 3.3.0.
+- Bump `cert-exporter` app to 2.7.0.
 - Bump `external-dns` app to 2.40.0.
 - Bump `net-exporter` app to 1.17.1.
 - Bump `node-exporter-app` app to 1.17.1.

--- a/helm/default-apps-eks/values.yaml
+++ b/helm/default-apps-eks/values.yaml
@@ -68,6 +68,7 @@ apps:
     appName: cert-exporter
     chartName: cert-exporter
     catalog: default
+    dependsOn: prometheus-operator-crd
     clusterValues:
       configMap: true
       secret: false
@@ -76,7 +77,7 @@ apps:
     namespace: kube-system
     # used by renovate
     # repo: giantswarm/cert-exporter
-    version: 2.6.0
+    version: 2.7.0
   certManager:
     appName: cert-manager
     chartName: cert-manager-app
@@ -120,6 +121,7 @@ apps:
     appName: net-exporter
     chartName: net-exporter
     catalog: default
+    dependsOn: prometheus-operator-crd
     clusterValues:
       configMap: true
       secret: false


### PR DESCRIPTION
### What this PR does / why we need it

Add latest cert-exporter so we can monitor if in EKS clusters

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!--
We currently have two different pipelines to test both cluster creation and cluster upgrades. You can trigger these pipelines by writing these commands in a pull request comment or description
- `/test create` : this will trigger the `create-cluster-capi-pure` pipeline.
- `/test upgrade` : this will trigger the `upgrade-cluster-capi-pure` pipeline.

After writing these comments, the pipelines are triggered in [tekton](https://tekton.giantswarm.io/#/pipelineruns). Eventually, the Github checks `create` and `upgrade` for these pipelines should show up in the commit statuses.
It may happen that the status is never shown on Github UI. If you want to check the status or result of the pipelines you can check [tekton](https://tekton.giantswarm.io/#/pipelineruns).

If for some reason you want to skip the e2e tests, remove the following lines.
-->

/test create
/test upgrade
/run cluster-test-suites
