### PR TITLE
Add chart-operator-extensions and regenerate Helm values.schema.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added `chart-operator-extension` version `v1.1.1` that contains e.g. `ServiceMonitors` for `chart-operator`.
+
 ### Changed
 
 - Bump `cert-manager-app` app to 3.4.0.

--- a/helm/default-apps-eks/values.schema.json
+++ b/helm/default-apps-eks/values.schema.json
@@ -28,6 +28,9 @@
                                 }
                             }
                         },
+                        "enabled": {
+                            "type": "boolean"
+                        },
                         "forceUpgrade": {
                             "type": "boolean"
                         },
@@ -61,6 +64,12 @@
                                     "type": "boolean"
                                 }
                             }
+                        },
+                        "dependsOn": {
+                            "type": "string"
+                        },
+                        "enabled": {
+                            "type": "boolean"
                         },
                         "forceUpgrade": {
                             "type": "boolean"
@@ -96,7 +105,47 @@
                                 }
                             }
                         },
+                        "enabled": {
+                            "type": "boolean"
+                        },
                         "forceUpgrade": {
+                            "type": "boolean"
+                        },
+                        "namespace": {
+                            "type": "string"
+                        },
+                        "version": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "chartOperatorExtensions": {
+                    "type": "object",
+                    "properties": {
+                        "appName": {
+                            "type": "string"
+                        },
+                        "catalog": {
+                            "type": "string"
+                        },
+                        "chartName": {
+                            "type": "string"
+                        },
+                        "clusterValues": {
+                            "type": "object",
+                            "properties": {
+                                "configMap": {
+                                    "type": "boolean"
+                                },
+                                "secret": {
+                                    "type": "boolean"
+                                }
+                            }
+                        },
+                        "dependsOn": {
+                            "type": "string"
+                        },
+                        "enabled": {
                             "type": "boolean"
                         },
                         "namespace": {
@@ -129,6 +178,9 @@
                                     "type": "boolean"
                                 }
                             }
+                        },
+                        "enabled": {
+                            "type": "boolean"
                         },
                         "forceUpgrade": {
                             "type": "boolean"
@@ -164,6 +216,9 @@
                                 }
                             }
                         },
+                        "enabled": {
+                            "type": "boolean"
+                        },
                         "forceUpgrade": {
                             "type": "boolean"
                         },
@@ -197,6 +252,12 @@
                                     "type": "boolean"
                                 }
                             }
+                        },
+                        "dependsOn": {
+                            "type": "string"
+                        },
+                        "enabled": {
+                            "type": "boolean"
                         },
                         "forceUpgrade": {
                             "type": "boolean"
@@ -232,6 +293,9 @@
                                 }
                             }
                         },
+                        "enabled": {
+                            "type": "boolean"
+                        },
                         "forceUpgrade": {
                             "type": "boolean"
                         },
@@ -265,6 +329,9 @@
                                     "type": "boolean"
                                 }
                             }
+                        },
+                        "enabled": {
+                            "type": "boolean"
                         },
                         "forceUpgrade": {
                             "type": "boolean"
@@ -306,6 +373,9 @@
                         "dependsOn": {
                             "type": "string"
                         },
+                        "enabled": {
+                            "type": "boolean"
+                        },
                         "forceUpgrade": {
                             "type": "boolean"
                         },
@@ -319,6 +389,9 @@
                 }
             }
         },
+        "awsAccoundID": {
+            "type": "string"
+        },
         "clusterName": {
             "type": "string"
         },
@@ -329,19 +402,6 @@
             "type": "object",
             "properties": {
                 "certManager": {
-                    "type": "object",
-                    "properties": {
-                        "configMap": {
-                            "type": "object",
-                            "properties": {
-                                "values": {
-                                    "type": "string"
-                                }
-                            }
-                        }
-                    }
-                },
-                "etcdKubernetesResourceCountExporter": {
                     "type": "object",
                     "properties": {
                         "configMap": {
@@ -368,6 +428,19 @@
                     }
                 },
                 "netExporter": {
+                    "type": "object",
+                    "properties": {
+                        "configMap": {
+                            "type": "object",
+                            "properties": {
+                                "values": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                },
+                "observabilityBundle": {
                     "type": "object",
                     "properties": {
                         "configMap": {

--- a/helm/default-apps-eks/values.yaml
+++ b/helm/default-apps-eks/values.yaml
@@ -97,8 +97,8 @@ apps:
     catalog: default
     enabled: true
     clusterValues:
-      configMap: true
-      secret: true
+      configMap: false
+      secret: false
     dependsOn: prometheus-operator-crd
     namespace: giantswarm
     # used by renovate

--- a/helm/default-apps-eks/values.yaml
+++ b/helm/default-apps-eks/values.yaml
@@ -101,6 +101,8 @@ apps:
       secret: true
     dependsOn: prometheus-operator-crd
     namespace: giantswarm
+    # used by renovate
+    # repo: giantswarm/chart-operator-extensions
     version: 1.1.1
   externalDns:
     appName: external-dns

--- a/helm/default-apps-eks/values.yaml
+++ b/helm/default-apps-eks/values.yaml
@@ -91,6 +91,17 @@ apps:
     # used by renovate
     # repo: giantswarm/cert-manager-app
     version: 3.4.0
+  chartOperatorExtensions:
+    appName: chart-operator-extensions
+    chartName: chart-operator-extensions
+    catalog: default
+    enabled: true
+    clusterValues:
+      configMap: true
+      secret: true
+    dependsOn: prometheus-operator-crd
+    namespace: giantswarm
+    version: 1.1.1
   externalDns:
     appName: external-dns
     chartName: external-dns-app


### PR DESCRIPTION
### What this PR does / why we need it

Towards: https://github.com/giantswarm/giantswarm/issues/27558

Add `chart-operator-extensions` that contains service monitors for `chart-operator`. As of that, it depends on `prometheus-operator-crd`.

Also regenerated `values.schema.json` because of the updated `values.yaml` file.

This will fully take effect after bumping chart operator beyond: https://github.com/giantswarm/chart-operator/pull/1029 (Will be released as `chart-operator` version `v3.0.0` probably).

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!--
We currently have one pipeline that tests both cluster creation and cluster upgrades. You can trigger this pipeline by writing this commands in a pull request comment or description
- `/run cluster-test-suites`

If for some reason you want to skip the e2e tests, remove the following line.
-->

/run cluster-test-suites
