### PR TITLE
metrics-server-remove-hostnetwork

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Remove `hostNetwork` setting for `metrics-server`.
+
 ## [0.2.0] - 2023-10-12
 
 ### Added

--- a/helm/default-apps-eks/values.yaml
+++ b/helm/default-apps-eks/values.yaml
@@ -45,7 +45,6 @@ userConfig:
       values: |
         ciliumNetworkPolicy:
           enabled: true
-        hostNetwork: true
   netExporter:
     configMap:
       values: |


### PR DESCRIPTION
remove hostnetwork for metrics server, as we have cilium in ENI mode this is no longer an issue
fix for https://github.com/giantswarm/giantswarm/issues/28483