### PR TITLE
Run e2e on Ronovate PRs automatically

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -3,4 +3,8 @@
     // Base config - https://github.com/giantswarm/renovate-presets/blob/main/default.json5
     "github>giantswarm/renovate-presets:default.json5",
   ],
+  "prBodyNotes": [
+    "Trigger E2E tests:",
+    "/run cluster-test-suites"
+  ]
 }


### PR DESCRIPTION
### What this PR does / why we need it
This change adds the trigger text to the Renovate PRs to trigger an e2e test.

issue: https://github.com/giantswarm/giantswarm/issues/29379

### Checklist

- [ ] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!--
We currently have one pipeline that tests both cluster creation and cluster upgrades. You can trigger this pipeline by writing this commands in a pull request comment or description
- `/run cluster-test-suites`

If for some reason you want to skip the e2e tests, remove the following line.
-->

/run cluster-test-suites

