### PR TITLE
Teleport kube agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Added
 
-- Inluded `teleport-kube-agent` by default on EKS clusters.
+- Included `teleport-kube-agent` app by default on EKS clusters.
 
 ## [0.5.1] - 2024-02-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## Added
+
+- Inluded `teleport-kube-agent` by default on EKS clusters.
+
 ## [0.5.1] - 2024-02-13
 
 ### Added

--- a/helm/default-apps-eks/templates/apps.yaml
+++ b/helm/default-apps-eks/templates/apps.yaml
@@ -58,7 +58,7 @@ spec:
     name: {{ tpl $extraConfig.name $ }}
     namespace: {{ tpl $extraConfig.namespace $ }}
     {{- if $extraConfig.priority }}
-    priotity: {{ $extraConfig.priority }}
+    priority: {{ $extraConfig.priority }}
     {{- end}}
   {{- end }}
   {{- end }}

--- a/helm/default-apps-eks/templates/apps.yaml
+++ b/helm/default-apps-eks/templates/apps.yaml
@@ -49,8 +49,16 @@ spec:
       name: {{ $.Values.clusterName }}-cluster-values
       namespace: {{ $.Release.Namespace }}
   {{- end }}
-  {{- end }} 
+  {{- end }}
 {{- end }}
+  {{- if .extraConfigs }}
+  extraConfigs:
+  {{- range $extraConfig := .extraConfigs }}
+  - kind: {{ $extraConfig.kind }}
+    name: {{ tpl $extraConfig.name $ }}
+    namespace: {{ tpl $extraConfig.namespace $ }}
+  {{- end }}
+  {{- end }}
 {{- with (get $.Values.userConfig $key) }}
   userConfig:
   {{- if .configMap }}

--- a/helm/default-apps-eks/templates/apps.yaml
+++ b/helm/default-apps-eks/templates/apps.yaml
@@ -57,6 +57,9 @@ spec:
   - kind: {{ $extraConfig.kind }}
     name: {{ tpl $extraConfig.name $ }}
     namespace: {{ tpl $extraConfig.namespace $ }}
+    {{- if $extraConfig.priority }}
+    priotity: {{ $extraConfig.priority }}
+    {{- end}}
   {{- end }}
   {{- end }}
 {{- with (get $.Values.userConfig $key) }}

--- a/helm/default-apps-eks/values.yaml
+++ b/helm/default-apps-eks/values.yaml
@@ -142,7 +142,7 @@ apps:
     namespace: kube-system
     # used by renovate
     # repo: giantswarm/coredns-app
-    version: 1.17.0
+    version: 1.21.0
   externalDns:
     appName: external-dns
     chartName: external-dns-app

--- a/helm/default-apps-eks/values.yaml
+++ b/helm/default-apps-eks/values.yaml
@@ -131,6 +131,18 @@ apps:
     # used by renovate
     # repo: giantswarm/cluster-autoscaler-app
     version: 1.27.3-gs5
+  coreDNS:
+    appName: coredns
+    chartName: coredns-app
+    catalog: default
+    clusterValues:
+      configMap: true
+      secret: false
+    forceUpgrade: true
+    namespace: kube-system
+    # used by renovate
+    # repo: giantswarm/coredns-app
+    version: 1.17.0
   externalDns:
     appName: external-dns
     chartName: external-dns-app

--- a/helm/default-apps-eks/values.yaml
+++ b/helm/default-apps-eks/values.yaml
@@ -138,10 +138,11 @@ apps:
     clusterValues:
       configMap: true
       secret: false
+    enabled: true
     forceUpgrade: true
     namespace: kube-system
     # used by renovate
-    # repo: giantswarm/coredns-app
+    # repo: giantswarm/cluster-autoscaler-app
     version: 1.21.0
   externalDns:
     appName: external-dns

--- a/helm/default-apps-eks/values.yaml
+++ b/helm/default-apps-eks/values.yaml
@@ -131,19 +131,6 @@ apps:
     # used by renovate
     # repo: giantswarm/cluster-autoscaler-app
     version: 1.27.3-gs5
-  coreDNS:
-    appName: coredns
-    chartName: coredns-app
-    catalog: default
-    clusterValues:
-      configMap: true
-      secret: false
-    enabled: true
-    forceUpgrade: true
-    namespace: kube-system
-    # used by renovate
-    # repo: giantswarm/cluster-autoscaler-app
-    version: 1.21.0
   externalDns:
     appName: external-dns
     chartName: external-dns-app

--- a/helm/default-apps-eks/values.yaml
+++ b/helm/default-apps-eks/values.yaml
@@ -219,7 +219,7 @@ apps:
     namespace: kube-system
     # used by renovate
     # repo: giantswarm/teleport-kube-agent-app
-    version: 0.7.0
+    version: 0.7.1
     # a list of extraConfigs for the App,
     # It can be secret or configmap
     # https://github.com/giantswarm/rfc/tree/main/multi-layer-app-config#example

--- a/helm/default-apps-eks/values.yaml
+++ b/helm/default-apps-eks/values.yaml
@@ -206,7 +206,7 @@ apps:
     namespace: kube-system
     # used by renovate
     # repo: giantswarm/observability-bundle
-    version: 1.1.0
+    version: 1.2.1
   teleport-kube-agent:
     appName: teleport-kube-agent
     chartName: teleport-kube-agent

--- a/helm/default-apps-eks/values.yaml
+++ b/helm/default-apps-eks/values.yaml
@@ -227,7 +227,6 @@ apps:
       - kind: configMap
         name: "{{ $.Values.clusterName }}-teleport-kube-agent-config"
         namespace: "{{ $.Release.Namespace }}"
-    version: 1.2.1
 providerSpecific:
   awsAccountId: ""
   awsClusterRoleIdentityName: ""

--- a/helm/default-apps-eks/values.yaml
+++ b/helm/default-apps-eks/values.yaml
@@ -225,6 +225,7 @@ apps:
     # https://github.com/giantswarm/rfc/tree/main/multi-layer-app-config#example
     extraConfigs:
       - kind: configMap
+        # Created by teleport-operator
         name: "{{ $.Values.clusterName }}-teleport-kube-agent-config"
         namespace: "{{ $.Release.Namespace }}"
 providerSpecific:

--- a/helm/default-apps-eks/values.yaml
+++ b/helm/default-apps-eks/values.yaml
@@ -212,7 +212,26 @@ apps:
     # used by renovate
     # repo: giantswarm/observability-bundle
     version: 1.1.0
-
+  teleport-kube-agent:
+    appName: teleport-kube-agent
+    chartName: teleport-kube-agent
+    catalog: default
+    clusterValues:
+      configMap: true
+      secret: true
+    enabled: true
+    forceUpgrade: true
+    namespace: kube-system
+    # used by renovate
+    # repo: giantswarm/teleport-kube-agent-app
+    version: 0.7.0
+    # a list of extraConfigs for the App,
+    # It can be secret or configmap
+    # https://github.com/giantswarm/rfc/tree/main/multi-layer-app-config#example
+    extraConfigs:
+      - kind: configMap
+        name: "{{ $.Values.clusterName }}-teleport-kube-agent-config"
+        namespace: "{{ $.Release.Namespace }}"
 providerSpecific:
   awsAccountId: ""
   awsClusterRoleIdentityName: ""


### PR DESCRIPTION
### What this PR does / why we need it

- This PR installs `teleport-kube-agent` by default on EKS clusters.

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!--
We currently have one pipeline that tests both cluster creation and cluster upgrades. You can trigger this pipeline by writing this commands in a pull request comment or description
- `/run cluster-test-suites`

If for some reason you want to skip the e2e tests, remove the following line.
-->

/run cluster-test-suites

