### PR TITLE
Add toleration for uninitialized nodes to kyverno

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add `k8s-dns-node-cache` app.
+- Add toleration for `uninitialized` nodes to the kyverno admission controller.
+
 
 ## [0.6.0] - 2024-03-20
 

--- a/helm/default-apps-eks/values.yaml
+++ b/helm/default-apps-eks/values.yaml
@@ -60,6 +60,20 @@ userConfig:
       values:
         NetExporter:
           NTPServers: 169.254.169.123
+  securityBundle:
+    configMap:
+      values:
+        userConfig:
+          kyverno:
+            configMap:
+              values:
+                kyverno:
+                  admissionController:
+                    tolerations:
+                    - key: "node.cluster.x-k8s.io/uninitialized"
+                      operator: "Exists"
+                      effect: "NoSchedule"
+
 apps:
   capi-node-labeler:
     appName: capi-node-labeler


### PR DESCRIPTION
### What this PR does / why we need it

Towards https://github.com/giantswarm/giantswarm/issues/29195
This will speed up upgrades where both control-plane and worker nodes get rolled at the same time.

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!--
We currently have one pipeline that tests both cluster creation and cluster upgrades. You can trigger this pipeline by writing this commands in a pull request comment or description
- `/run cluster-test-suites`

If for some reason you want to skip the e2e tests, remove the following line.
-->

/run cluster-test-suites

